### PR TITLE
emacs: fix typo and add missing autoloads for prot-project.el

### DIFF
--- a/emacs/.emacs.d/prot-emacs-modules/prot-emacs-git.el
+++ b/emacs/.emacs.d/prot-emacs-modules/prot-emacs-git.el
@@ -20,6 +20,7 @@
   (advice-add #'project-switch-project :after #'prot-common-clear-minibuffer-message)
 
   (autoload #'prot-project-maybe-in-tab "prot-project")
+  (autoload #'prot-project-switch "prot-project")
   (define-key project-prefix-map (kbd "p") #'prot-project-maybe-in-tab))
 
 ;;;; `diff-mode'

--- a/emacs/.emacs.d/prot-emacs.org
+++ b/emacs/.emacs.d/prot-emacs.org
@@ -6786,6 +6786,7 @@ functionality I rely on, so do take a look at what it has to offer.
   (advice-add #'project-switch-project :after #'prot-common-clear-minibuffer-message)
 
   (autoload #'prot-project-maybe-in-tab "prot-project")
+  (autoload #'prot-project-switch "prot-project")
   (define-key project-prefix-map (kbd "p") #'prot-project-maybe-in-tab))
 #+end_src
 
@@ -18461,7 +18462,7 @@ Also see `prot-window-delete-popup-frame'." command)
 ;;;###autoload (autoload 'prot-window-popup-tmr "prot-window")
 (prot-window-define-with-popup-frame tmr)  ; defines command `prot-window-popup-tmr'
 
-;;;###autoload (autoload 'prot-window-popup-tmr "prot-window")
+;;;###autoload (autoload 'prot-window-popup-prot-project-switch "prot-window")
 (prot-window-define-with-popup-frame prot-project-switch)  ; defines command `prot-window-popup-prot-project-switch'
 
 (defun prot-window-set-delete-popup-hook (feature hook)

--- a/emacs/.emacs.d/prot-lisp/prot-window.el
+++ b/emacs/.emacs.d/prot-lisp/prot-window.el
@@ -233,7 +233,7 @@ Also see `prot-window-delete-popup-frame'." command)
 ;;;###autoload (autoload 'prot-window-popup-tmr "prot-window")
 (prot-window-define-with-popup-frame tmr)  ; defines command `prot-window-popup-tmr'
 
-;;;###autoload (autoload 'prot-window-popup-tmr "prot-window")
+;;;###autoload (autoload 'prot-window-popup-prot-project-switch "prot-window")
 (prot-window-define-with-popup-frame prot-project-switch)  ; defines command `prot-window-popup-prot-project-switch'
 
 (defun prot-window-set-delete-popup-hook (feature hook)


### PR DESCRIPTION
1. Fix typo in `prot-window-popup-tmr` -> should be `prot-window-popup-prot-project-switch`
2. Add missing autoloads `prot-project-switch` for prot-project.el
   * This is used by the `prot-window-popup-prot-project-switch` function